### PR TITLE
Fix double click jump not tracking history correctly on 7.6

### DIFF
--- a/HexRaysPyTools/callbacks/member_double_click.py
+++ b/HexRaysPyTools/callbacks/member_double_click.py
@@ -37,7 +37,7 @@ class MemberDoubleClick(callbacks.HexRaysEventHandler):
             func_name = helper.get_member_name(vtable_tinfo, method_offset)
             func_ea = helper.choose_virtual_func_address(func_name, class_tinfo, vtable_offset)
             if func_ea:
-                idaapi.open_pseudocode(func_ea, 0)
+                idaapi.jumpto(func_ea)
                 return 1
 
 callbacks.hx_callback_manager.register(idaapi.hxe_double_click, MemberDoubleClick())


### PR DESCRIPTION
The API was changed in 7.6, open_pseudocode causes the wrong history to be pushed (resulting in trying to go backwards, just reopening the same function). According to support, this is because open_pseudocode was not supposed to use the navigation history, and jumpto is supposed to be used instead.